### PR TITLE
Fix: Replace motion/react import with framer-motion

### DIFF
--- a/components/ui/glowing-effect.tsx
+++ b/components/ui/glowing-effect.tsx
@@ -2,7 +2,7 @@
 
 import { memo, useCallback, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
-import { animate } from "motion/react";
+import { animate } from "framer-motion";
 
 interface GlowingEffectProps {
   blur?: number;


### PR DESCRIPTION
This PR fixes the build error caused by the improper import path in the glowing-effect.tsx component.

### Changes
- Changed `import { animate } from "motion/react";` to `import { animate } from "framer-motion";`

### Issue Fixed
The original import was causing a build error:
```
Module not found: Can't resolve 'motion/react'

./components/ui/glowing-effect.tsx (5:1)

Module not found: Can't resolve 'motion/react'
```

This change uses the framer-motion package that's already in the dependencies list, which provides the same animation functionality and resolves the build error.